### PR TITLE
feat: add life skills for teenagers section and nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       "@type": "LocalBusiness",
       "name": "Shalom Therapy",
       "image": "https://www.shalom-therapy.com/images/shalom-therapy-og-image.jpg",
-      "description": "Professional online counselling in Kochi by Manju George. Expert therapist in Kochi offering online therapy sessions for anxiety, stress, relationships, and personal growth.",
+      "description": "Professional online counselling and teen life skills training by Manju George. Expert therapist in Kochi offering therapy for anxiety, stress, relationships, personal growth, and life skills training for teenagers abroad and children with special needs.",
       "address": {
         "@type": "PostalAddress",
         "addressLocality": "Kochi",
@@ -41,7 +41,7 @@
         "addressCountry": "IN"
       },
       "url": "https://www.shalom-therapy.com",
-      "priceRange": "₹₹",
+      "priceRange": "\u20b9\u20b9",
       "sameAs": [
         "https://www.facebook.com/shalomtherapy",
         "https://www.instagram.com/shalomtherapy"
@@ -58,32 +58,32 @@
         "@type": "Organization",
         "name": "Shalom Therapy"
       },
-      "description": "Professional counselling psychologist providing mental health services in Kochi and online therapy across India."
+      "description": "Professional counselling psychologist and life skills trainer providing mental health services and teen life skills training in Kochi and online across India."
     }
     </script>
     
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Professional Online Counselling | Therapist Services | Shalom Therapy</title>
-    <meta name="description" content="Professional online counselling in Kochi by Manju George. Expert therapist in Kochi offering online therapy sessions for anxiety, stress, relationships, and personal growth.">
-    <meta name="keywords" content="therapist kochi, online counselling kochi, mental health kochi, online therapy, counselling, psychologist kochi, Shalom Therapy">
+    <title>Professional Online Counselling &amp; Teen Life Skills Training | Shalom Therapy</title>
+    <meta name="description" content="Professional online counselling and life skills training for teenagers by Manju George, Kochi. Therapy for anxiety, stress, relationships, and personal growth. Life skills programs for teens living abroad and children with special needs.">
+    <meta name="keywords" content="therapist kochi, online counselling kochi, mental health kochi, online therapy, counselling, psychologist kochi, Shalom Therapy, life skills training teenagers, teen life skills online India, NRI teen support, special needs children counselling, life skills coach online Kerala">
     <meta name="author" content="Manju George">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://www.shalom-therapy.com">
     <link rel="icon" type="image/avif" href="assets/logo_favicon.png">
     <link rel="icon" type="image/x-icon" href="assets/logo_favicon.png">
     <link rel="shortcut icon" type="image/x-icon" href="assets/logo_favicon.png">
-    <meta property="og:title" content="Professional Online Counselling | Therapist Services | Shalom Therapy">
-    <meta property="og:description" content="Professional online counselling in Kochi by Manju George. Expert therapist in Kochi offering online therapy sessions for anxiety, stress, relationships, and personal growth.">
+    <meta property="og:title" content="Professional Online Counselling &amp; Teen Life Skills Training | Shalom Therapy">
+    <meta property="og:description" content="Professional online counselling and life skills training for teenagers by Manju George, Kochi. Therapy for anxiety, stress, relationships, and personal growth. Life skills programs for teens living abroad and children with special needs.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.shalomtherapy.in">
-    <meta property="og:image" content="https://www.shalomtherapy.in/images/shalom-therapy-og-image.jpg">
+    <meta property="og:url" content="https://www.shalom-therapy.com">
+    <meta property="og:image" content="https://www.shalom-therapy.com/images/shalom-therapy-og-image.jpg">
     <meta property="og:locale" content="en_IN">
     <meta property="og:site_name" content="Shalom Therapy">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Professional Online Counselling | Therapist Services | Shalom Therapy">
-    <meta name="twitter:description" content="Professional online counselling in Kochi by Manju George. Expert therapist in Kochi offering online therapy sessions for anxiety, stress, relationships, and personal growth.">
+    <meta name="twitter:title" content="Professional Online Counselling &amp; Teen Life Skills Training | Shalom Therapy">
+    <meta name="twitter:description" content="Professional online counselling and life skills training for teenagers by Manju George, Kochi. Therapy for anxiety, stress, relationships, and personal growth.">
     <meta name="twitter:image" content="https://www.shalom-therapy.com/images/shalom-therapy-og-image.jpg">
     <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml">
     <link rel="alternate" href="https://www.shalom-therapy.com" hreflang="en-in" />
@@ -205,6 +205,62 @@
             margin-top: 0;
             margin-bottom: 30px;
         }
+
+        /* Hero path cards */
+        .hero-paths {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+            margin-top: 40px;
+            flex-wrap: wrap;
+        }
+
+        .hero-path-card {
+            background-color: rgba(255,255,255,0.65);
+            border: 1px solid rgba(255,255,255,0.9);
+            padding: 28px 36px;
+            min-width: 240px;
+            max-width: 300px;
+            text-align: center;
+            transition: background-color 0.3s, transform 0.3s;
+        }
+
+        .hero-path-card:hover {
+            background-color: rgba(255,255,255,0.85);
+            transform: translateY(-3px);
+        }
+
+        .hero-path-card h3 {
+            font-family: 'Playfair Display', serif;
+            font-size: 20px;
+            color: #2d2d2d;
+            margin-bottom: 10px;
+            font-weight: 500;
+        }
+
+        .hero-path-card p {
+            font-size: 13px;
+            color: #5a5a5a;
+            margin-bottom: 18px;
+            line-height: 1.5;
+        }
+
+        .hero-path-card a {
+            display: inline-block;
+            background-color: #e2d3c8;
+            color: #4a4a4a;
+            padding: 10px 24px;
+            text-decoration: none;
+            font-weight: 500;
+            text-transform: uppercase;
+            letter-spacing: 1.5px;
+            font-size: 12px;
+            transition: background-color 0.3s;
+        }
+
+        .hero-path-card a:hover {
+            background-color: #c3b1a9;
+        }
         
         /* Featured Section */
         .featured-section {
@@ -305,6 +361,115 @@
         
         .service-card p {
             color: #777;
+        }
+
+        /* Life Skills Section */
+        .life-skills-section {
+            padding: 80px 0;
+            background-color: #d5e0d8;
+        }
+
+        .life-skills-section .section-title {
+            color: #2d2d2d;
+        }
+
+        .life-skills-intro {
+            max-width: 760px;
+            margin: 0 auto 50px;
+            padding: 0 20px;
+            text-align: center;
+            color: #3a3a3a;
+            font-size: 17px;
+            line-height: 1.8;
+        }
+
+        .life-skills-intro .ls-tagline {
+            font-family: 'Playfair Display', serif;
+            font-size: 20px;
+            color: #2d2d2d;
+            font-style: italic;
+            margin-bottom: 18px;
+        }
+
+        .life-skills-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+            gap: 24px;
+            max-width: 1200px;
+            margin: 0 auto 50px;
+            padding: 0 20px;
+        }
+
+        .life-skills-card {
+            background-color: rgba(255,255,255,0.65);
+            border: 1px solid rgba(255,255,255,0.85);
+            padding: 26px 28px;
+            transition: background-color 0.3s, transform 0.3s;
+        }
+
+        .life-skills-card:hover {
+            background-color: rgba(255,255,255,0.85);
+            transform: translateY(-3px);
+        }
+
+        .life-skills-card h4 {
+            font-family: 'Playfair Display', serif;
+            font-size: 18px;
+            color: #2d2d2d;
+            margin-bottom: 10px;
+            font-weight: 500;
+        }
+
+        .life-skills-card p {
+            font-size: 14px;
+            color: #4a4a4a;
+            line-height: 1.6;
+        }
+
+        .life-skills-special {
+            max-width: 900px;
+            margin: 0 auto 50px;
+            padding: 36px 40px;
+            background-color: rgba(255,255,255,0.5);
+            border: 1px solid rgba(255,255,255,0.8);
+            text-align: center;
+        }
+
+        .life-skills-special h3 {
+            font-family: 'Playfair Display', serif;
+            font-size: 26px;
+            color: #2d2d2d;
+            margin-bottom: 16px;
+            font-weight: 400;
+        }
+
+        .life-skills-special p {
+            color: #3a3a3a;
+            font-size: 16px;
+            line-height: 1.8;
+            max-width: 680px;
+            margin: 0 auto;
+        }
+
+        .life-skills-cta {
+            text-align: center;
+        }
+
+        .life-skills-cta a {
+            display: inline-block;
+            background-color: #4a4a4a;
+            color: #f8f6f2;
+            padding: 15px 44px;
+            text-decoration: none;
+            font-weight: 500;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            font-size: 14px;
+            transition: background-color 0.3s;
+        }
+
+        .life-skills-cta a:hover {
+            background-color: #2d2d2d;
         }
         
         /* Button Styles */
@@ -682,6 +847,17 @@
             .hero-subtitle {
                 font-size: 28px;
             }
+            .hero-paths {
+                flex-direction: column;
+                align-items: center;
+            }
+            .hero-path-card {
+                min-width: 280px;
+                max-width: 100%;
+            }
+            .life-skills-special {
+                padding: 28px 20px;
+            }
         }
     </style>
 </head>
@@ -696,6 +872,7 @@
                 <li><a href="#home" class="active">HOME</a></li>
                 <li><a href="#about">ABOUT</a></li>
                 <li><a href="#services">SERVICES</a></li>
+                <li><a href="#life-skills">LIFE SKILLS FOR TEENS</a></li>
                 <li><a href="#blog">BLOG</a></li>
                 <li><a href="#contact">BOOK NOW</a></li>
             </ul>
@@ -706,6 +883,18 @@
         <div class="hero-content">
             <h1 class="hero-title">Shalom Therapy</h1>
             <h2 class="hero-subtitle">Professional Counselling Services</h2>
+            <div class="hero-paths">
+                <div class="hero-path-card">
+                    <h3>Counselling &amp; Therapy</h3>
+                    <p>Individual therapy for adults &mdash; anxiety, stress, relationships, grief, and personal growth.</p>
+                    <a href="#services">Explore Services</a>
+                </div>
+                <div class="hero-path-card">
+                    <h3>Life Skills for Teenagers</h3>
+                    <p>Online programs for teens living abroad and children with special needs &mdash; building confidence and resilience.</p>
+                    <a href="#life-skills">Learn More</a>
+                </div>
+            </div>
         </div>
     </section>
 
@@ -721,7 +910,7 @@
                     <h4>Counselling Psychologist</h4>
                     <p>Manju is a counselling psychologist with expertise in guiding individuals through emotional and personal growth challenges. At Shalom Therapy, she believes that true healing comes from understanding the whole person, not just treating symptoms.</p>
                     <p>With advanced degrees in Counselling and Developmental Psychology from the University of Kent, UK and certifications in Person-Centered Psychotherapy and Special Needs Education, she offers a compassionate, client-focused approach that empowers you to discover your own solutions.</p>
-                    <p>Based out of Kochi, she provides a safe, supportive environment where you can explore your thoughts and feelings without judgment, developing the insights and skills needed to overcome challenges and live a more fulfilling life. Her online therapy sessions are available to clients throughout India.</p>
+                    <p>Based out of Kochi, she provides a safe, supportive environment where you can explore your thoughts and feelings without judgment, developing the insights and skills needed to overcome challenges and live a more fulfilling life. Her online therapy sessions are available to clients throughout India. Her background in Developmental Psychology and Special Needs Education also forms the foundation of Shalom Therapy's Life Skills Training programme, designed to support teenagers &mdash; including children with diverse learning and developmental needs.</p>
                 </div>
             </div>
             <div class="therapist-card">
@@ -747,16 +936,16 @@
                 <p>Personalized therapy sessions using a person-centered approach that respects your unique perspective and empowers you to discover your own solutions for mental health and personal growth.</p>
             </div>
             <div class="service-card">
-                <h3>Anxiety & Stress Management</h3>
+                <h3>Anxiety &amp; Stress Management</h3>
                 <p>Evidence-based techniques including Cognitive Behavioral Therapy (CBT) and mindfulness interventions to help manage anxiety, reclaim calm, and develop effective stress management strategies.</p>
             </div>
             <div class="service-card">
-                <h3>Self-Esteem & Personal Growth</h3>
+                <h3>Self-Esteem &amp; Personal Growth</h3>
                 <p>Supportive guidance to address low self-esteem and build confidence, using motivational techniques and resilience training to help you recognize your worth and potential.</p>
             </div>
             <div class="service-card">
-                <h3>Grief Counselling</h3>
-                <p>Compassionate support through the grief process, helping you navigate loss and find healing with empathetic listening and specialized grief counselling techniques.</p>
+                <h3>Life Skills Training for Teenagers</h3>
+                <p>Interactive online sessions empowering teens with emotional regulation, communication, decision-making, digital safety, and stress management. Especially designed for children living abroad and children with special needs.</p>
             </div>
             <div class="service-card">
                 <h3>Relationship Counselling</h3>
@@ -766,6 +955,58 @@
                 <h3>Special Needs Support</h3>
                 <p>Specialized assistance for children with exceptional needs and their families, using individualized strategies developed through extensive experience in special education.</p>
             </div>
+        </div>
+    </section>
+
+    <section id="life-skills" class="life-skills-section">
+        <h2 class="section-title">Life Skills Training for Teenagers</h2>
+        <div class="life-skills-intro">
+            <p class="ls-tagline">Equipping young minds with skills that last a lifetime.</p>
+            <p>Our online Life Skills Training empowers teenagers to handle real-life challenges with confidence. Through engaging, interactive sessions, teens develop emotional control, communication, decision-making, digital safety, and stress management &mdash; essential foundations for success at school, at home, and in everyday life.</p>
+        </div>
+
+        <div class="life-skills-grid">
+            <div class="life-skills-card">
+                <h4>Communication</h4>
+                <p>Building the ability to express thoughts clearly, listen actively, and navigate conversations with confidence and empathy.</p>
+            </div>
+            <div class="life-skills-card">
+                <h4>Emotional Regulation</h4>
+                <p>Learning to understand, process, and manage emotions in healthy ways &mdash; a skill that supports every area of life.</p>
+            </div>
+            <div class="life-skills-card">
+                <h4>Decision-Making</h4>
+                <p>Developing critical thinking and sound judgement to make thoughtful choices under pressure and uncertainty.</p>
+            </div>
+            <div class="life-skills-card">
+                <h4>Stress Management</h4>
+                <p>Practical strategies to manage academic pressure, social anxiety, and the demands of a busy teenage life.</p>
+            </div>
+            <div class="life-skills-card">
+                <h4>Self-Confidence &amp; Resilience</h4>
+                <p>Cultivating a strong sense of self-worth and the inner resilience to recover from setbacks and embrace new challenges.</p>
+            </div>
+            <div class="life-skills-card">
+                <h4>Healthy Relationships</h4>
+                <p>Understanding boundaries, trust, and what it means to build and maintain respectful, fulfilling relationships.</p>
+            </div>
+            <div class="life-skills-card">
+                <h4>Cultural Adaptation</h4>
+                <p>Navigating identity, belonging, and social dynamics when living and studying in a new cultural environment.</p>
+            </div>
+            <div class="life-skills-card">
+                <h4>Digital Safety</h4>
+                <p>Responsible internet use, understanding digital footprints, and staying safe in online social environments.</p>
+            </div>
+        </div>
+
+        <div class="life-skills-special">
+            <h3>Designed for Teens Abroad &amp; Children with Special Needs</h3>
+            <p>The programme holds particular value for two groups who benefit most from tailored support. For teenagers living abroad, it addresses the unique pressures of cultural adjustment, academic transitions, and building a sense of belonging away from home. For children with special needs, Manju's certification in Special Needs Education ensures that sessions are thoughtfully adapted &mdash; pacing, communication style, and activities are shaped around each child's strengths and requirements. Every teenager deserves a programme that meets them where they are.</p>
+        </div>
+
+        <div class="life-skills-cta">
+            <a href="#contact">Book a Discovery Call for Your Teenager</a>
         </div>
     </section>
 
@@ -809,7 +1050,7 @@
                 <!-- Calendly Booking Button -->
                 <div class="booking-options">
                     <a href="https://calendly.com/manjugeorge-shalomtherapy/50-mins-session" target="_blank" class="calendly-button">
-                        📅 SCHEDULE ONLINE - BOOK NOW
+                        SCHEDULE ONLINE - BOOK NOW
                     </a>
                 </div>
 
@@ -834,7 +1075,7 @@
         <div class="footer-content">
             <div class="footer-col">
                 <h4>Shalom Therapy</h4>
-                <p>Providing compassionate, evidence-based counselling with expertise in guiding individuals through emotional and personal growth challenges.</p>
+                <p>Providing compassionate, evidence-based counselling and life skills training with expertise in guiding individuals through emotional and personal growth challenges.</p>
             </div>
             <div class="footer-col">
                 <h4>Quick Links</h4>
@@ -842,6 +1083,7 @@
                     <li><a href="#home">Home</a></li>
                     <li><a href="#about">About</a></li>
                     <li><a href="#services">Services</a></li>
+                    <li><a href="#life-skills">Life Skills for Teens</a></li>
                     <li><a href="#testimonials">Testimonials</a></li>
                     <li><a href="#blog">Blog</a></li>
                     <li><a href="#contact">Contact</a></li>
@@ -851,10 +1093,12 @@
                 <h4>Services</h4>
                 <ul>
                     <li><a href="#services">Individual Therapy</a></li>
-                    <li><a href="#services">Anxiety & Stress Management</a></li>
-                    <li><a href="#services">Self-Esteem & Personal Growth</a></li>
+                    <li><a href="#services">Anxiety &amp; Stress Management</a></li>
+                    <li><a href="#services">Self-Esteem &amp; Personal Growth</a></li>
                     <li><a href="#services">Grief Counselling</a></li>
+                    <li><a href="#services">Relationship Counselling</a></li>
                     <li><a href="#services">Special Needs Support</a></li>
+                    <li><a href="#life-skills">Life Skills Training for Teenagers</a></li>
                 </ul>
             </div>
         </div>
@@ -896,7 +1140,7 @@
                         }
                         throw new Error('Network response was not ok.');
                     })
-                    .then data => {
+                    .then(data => {
                         // Success message
                         formStatus.innerHTML = '<div class="form-success">Thank you for your message! I will get back to you soon.</div>';
                         contactForm.reset();
@@ -925,7 +1169,7 @@
           "image": "https://www.shalom-therapy.com/images/shalom-therapy-og-image.jpg",
           "url": "https://www.shalom-therapy.com",
           "telephone": "+91 9099056142",
-          "description": "Professional online counselling in Kochi by Manju George. Expert therapist in Kochi offering online therapy sessions for anxiety, stress, relationships, and personal growth.",
+          "description": "Professional online counselling and life skills training for teenagers in Kochi by Manju George. Expert therapist offering therapy for anxiety, stress, relationships, personal growth, and life skills programmes for teens living abroad and children with special needs.",
           "address": {
             "@type": "PostalAddress",
             "streetAddress": "Kochi",
@@ -953,7 +1197,7 @@
               "closes": "15:00"
             }
           ],
-          "priceRange": "₹₹",
+          "priceRange": "\u20b9\u20b9",
           "sameAs": []
         }
         </script>
@@ -963,14 +1207,14 @@
           "@context": "https://schema.org",
           "@type": "ProfessionalService",
           "name": "Shalom Therapy",
-          "description": "Professional online counselling in Kochi by Manju George. Expert therapist in Kochi offering online therapy sessions for anxiety, stress, relationships, and personal growth.",
+          "description": "Professional online counselling and life skills training for teenagers in Kochi by Manju George.",
           "provider": {
             "@type": "Person",
             "name": "Manju George",
             "jobTitle": "Therapist in Kochi",
-            "description": "Professional therapist in Kochi offering online counselling services for emotional and personal growth challenges."
+            "description": "Professional therapist in Kochi offering online counselling and life skills training for teenagers, including children living abroad and children with special needs."
           },
-          "serviceType": ["Online Counselling Kochi", "Therapist Kochi", "Online Therapy", "Mental Health Services"],
+          "serviceType": ["Online Counselling Kochi", "Therapist Kochi", "Online Therapy", "Mental Health Services", "Life Skills Training Teenagers", "Teen Life Skills Online India", "Special Needs Children Counselling"],
           "areaServed": [
             {
               "@type": "City",
@@ -983,7 +1227,7 @@
           ],
           "hasOfferCatalog": {
             "@type": "OfferCatalog",
-            "name": "Therapy Services",
+            "name": "Therapy and Life Skills Services",
             "itemListElement": [
               {
                 "@type": "Offer",
@@ -1025,6 +1269,13 @@
                 "itemOffered": {
                   "@type": "Service",
                   "name": "Special Needs Support"
+                }
+              },
+              {
+                "@type": "Offer",
+                "itemOffered": {
+                  "@type": "Service",
+                  "name": "Life Skills Training for Teenagers"
                 }
               }
             ]


### PR DESCRIPTION
- Add #life-skills section with skills grid, special needs & abroad focus
- Replace Grief Counselling card with Life Skills Training card in services grid (6 cards, 3x2 symmetry maintained)
- Add hero path cards for dual-audience routing
- Add Life Skills for Teens nav item
- Update Manju bio to reference Special Needs Education and Life Skills programme
- Manushi profile unchanged
- Update footer quick links and services list
- Update SEO: title, meta description, keywords, JSON-LD schema