### PR TITLE
Content: Refine Life Skills intro & NRI experience copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -972,8 +972,7 @@
         <h2 class="section-title">Life Skills for Young People</h2>
         <div class="life-skills-intro">
             <p class="ls-tagline">Equipping young minds with skills that last a lifetime.</p>
-            <p class="ls-story">Manju knows what it feels like to be far from home. She lived and studied abroad on her own &mdash; working as a substitute teacher in schools across Kent and London while completing her degree &mdash; navigating cultural shifts, new social environments, and the quiet pressures of building a life independently in a foreign country. That lived experience shapes the way she works with young people today.</p>
-            <p class="ls-story" style="margin-top: 16px;">Parents trust her not just because of her qualifications, but because she has genuinely been there. Through engaging, interactive online sessions, young people develop the emotional and social tools they need to thrive &mdash; at school, at home, and in everyday life.</p>
+            <p class="ls-story">Parents trust her not just because of her qualifications, but because she has genuinely been there. Through engaging, interactive online sessions, young people develop the emotional and social tools they need to thrive &mdash; at school, at home, and in everyday life.</p>
         </div>
 
         <div class="life-skills-grid">
@@ -1013,8 +1012,8 @@
 
         <div class="life-skills-special">
             <h3>For Families Abroad &amp; Children with Special Needs</h3>
-            <p>For families living abroad, Manju brings something most trainers can't: she's been that person navigating life in a new country. She understands the pressures NRI children and teenagers face &mdash; the cultural tightrope, the longing for familiarity, the effort of belonging &mdash; and she meets each young person with genuine empathy rather than a textbook framework.</p>
-            <p>For children with special needs, her certification in Special Needs Education ensures every session is thoughtfully adapted. Pacing, communication style, and activities are shaped around each child's strengths and individual requirements. Every young person deserves support that truly meets them where they are.</p>
+            <p>While completing her degree at the University of Kent, Manju worked as a substitute teacher in schools across Kent and London &mdash; and many of her students were NRI and international children facing the very same adjustments she was navigating as a student herself. The cultural tightrope, the longing for familiarity, the quiet work of belonging somewhere new &mdash; she knew it from both sides of the classroom. That&rsquo;s the understanding she brings to every young person she works with.</p>
+            <p>For children with special needs, her certification in Special Needs Education ensures every session is thoughtfully adapted. Pacing, communication style, and activities are shaped around each child&rsquo;s strengths and individual requirements. Every young person deserves support that truly meets them where they are.</p>
         </div>
 
         <div class="life-skills-cta">


### PR DESCRIPTION
## What this changes

### 1. Removed duplicate intro paragraph
The first `ls-story` paragraph ("Manju knows what it feels like to be far from home...") was saying the same thing as the first paragraph inside the `life-skills-special` box. Removed it to eliminate the repetition. The second intro paragraph ("Parents trust her not just because of her qualifications...") is retained as the sole intro.

### 2. Rewrote the box's first paragraph
Replaced the generic "she's been that person navigating life in a new country" line with a warmer, more specific story that:
- Clearly establishes that Manju was a **substitute teacher** while **pursuing her degree** at the University of Kent
- Names **NRI and international students** specifically as the children she taught
- Captures the dual perspective — feeling the same adjustments from **both sides of the classroom**
- Avoids any comparison to other trainers; lets the story speak for itself

### New box paragraph (Option C)
> *While completing her degree at the University of Kent, Manju worked as a substitute teacher in schools across Kent and London — and many of her students were NRI and international children facing the very same adjustments she was navigating as a student herself. The cultural tightrope, the longing for familiarity, the quiet work of belonging somewhere new — she knew it from both sides of the classroom. That's the understanding she brings to every young person she works with.*

No structural or styling changes — HTML, CSS, and all other sections are untouched.